### PR TITLE
Give the option to generate configuration on container startup

### DIFF
--- a/moosefs-cgi/Dockerfile
+++ b/moosefs-cgi/Dockerfile
@@ -13,4 +13,8 @@ RUN apt-get update && apt-get install -y moosefs-cgi moosefs-cgiserv moosefs-cli
 # Expose ports master ports
 EXPOSE 9425
 
-CMD ["mfscgiserv", "-f"]
+# Add start script
+ADD cgiserver.sh /usr/sbin/cgiserver.sh
+RUN chown root:root /usr/sbin/cgiserver.sh ; chmod 700 /usr/sbin/cgiserver.sh
+
+CMD ["cgiserver.sh"]

--- a/moosefs-cgi/cgiserver.sh
+++ b/moosefs-cgi/cgiserver.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+CMD="mfscgiserv -f"
+
+#Add host if set
+if [ ! -z ${MASTER_HOST+X} ];
+    then
+        CMD="$CMD -H $MASTER_HOST"
+fi
+
+#Add host if set
+if [ ! -z ${MASTER_PORT+X} ];
+    then
+        CMD="$CMD -P $MASTER_PORT"
+fi
+
+exec $CMD

--- a/moosefs-chunkserver/Dockerfile
+++ b/moosefs-chunkserver/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:buster
 
 # Install wget, lsb-release and curl
-RUN apt-get update && apt-get install -y wget gnupg2
+RUN apt-get update && apt-get install -y wget gnupg2 gettext-base
 
 # Add key
 RUN wget -O - http://ppa.moosefs.com/moosefs.key 2>/dev/null | apt-key add - 2>/dev/null

--- a/moosefs-chunkserver/chunkserver.sh
+++ b/moosefs-chunkserver/chunkserver.sh
@@ -1,9 +1,29 @@
 #!/usr/bin/env bash
 
+mkdir -p /mnt/hdd0/mfs
 # Set correct owner
-chown -R mfs:mfs /mnt/hdd0 /var/lib/mfs
+chown -R mfs:mfs /mnt/hdd0 /mnt/hdd0/mfs /var/lib/mfs
 
-#Add size to hdd is defined
+# Overwrite mfschunkserver.cfg if passed in
+# this will base64 decode MFS_CHUNKSERVER_CONFIG variable text
+# substitute any env variables in decoded text
+# save text into /etc/mfs/mfschunkserver.cfg
+if [ ! -z ${MFS_CHUNKSERVER_CONFIG+X} ];
+    then
+        echo $MFS_CHUNKSERVER_CONFIG | base64 -d | envsubst > /etc/mfs/mfschunkserver.cfg
+fi
+
+# Overwrite mfshdd.cfg if passed in
+# this will base64 decode MFS_HDD_CONFIG variable text
+# substitute any env variables in decoded text
+# save text into /etc/mfs/mfshdd.cfg
+if [ ! -z ${MFS_HDD_CONFIG+X} ];
+    then
+        echo $MFS_HDD_CONFIG | base64 -d | envsubst > /etc/mfs/mfshdd.cfg
+fi
+
+
+#Add size to hdd if defined
 if [ -z ${SIZE+X} ];
     then
         echo "/mnt/hdd0" > /etc/mfs/mfshdd.cfg

--- a/moosefs-client/Dockerfile
+++ b/moosefs-client/Dockerfile
@@ -10,7 +10,8 @@ RUN echo "deb http://ppa.moosefs.com/3.0.115/apt/debian/buster buster main" > /e
 # Install MooseFS client and cli
 RUN apt-get update && apt-get install -y moosefs-client moosefs-cli
 
-# Make a moosefs mountpoint
-RUN mkdir -p /mnt/moosefs
+# Add start script
+ADD mount.sh /usr/sbin/mount.sh
+RUN chown root:root /usr/sbin/mount.sh ; chmod 700 /usr/sbin/mount.sh ; mkdir -p /mnt/moosefs
 
-CMD ["mfsmount", "-f", "/mnt/moosefs"]
+CMD ["mount.sh"]

--- a/moosefs-client/mount.sh
+++ b/moosefs-client/mount.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+CMD="mfsmount /mnt/moosefs -f"
+
+#Add host if set
+if [ ! -z ${MASTER_HOST+X} ];
+    then
+        CMD="$CMD -H $MASTER_HOST"
+fi
+
+#Add host if set
+if [ ! -z ${MASTER_PORT+X} ];
+    then
+        CMD="$CMD -P $MASTER_PORT"
+fi
+
+exec $CMD

--- a/moosefs-master/master.sh
+++ b/moosefs-master/master.sh
@@ -6,6 +6,15 @@ MFS_ENV="${MFS_ENV:-PROD}"
 #Set correct owner
 chown -R mfs:mfs /var/lib/mfs
 
+# Overwrite mfsmaster.cfg if passed in
+# this will base64 decode MFS_MASTER_CONFIG variable text
+# substitute any env variables in decoded text
+# save text into /etc/mfs/mfsmaster.cfg
+if [ ! -z ${MFS_MASTER_CONFIG+X} ];
+    then
+        echo $MFS_MASTER_CONFIG | base64 -d | envsubst > /etc/mfs/mfsmaster.cfg
+fi
+
 # We have to be sure that we have metadata files
 if [ -f /var/lib/mfs/metadata.mfs ];
 then

--- a/moosefs-metalogger/Dockerfile
+++ b/moosefs-metalogger/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:buster
 
 # Install wget and gnupg2
-RUN apt-get update && apt-get install -y wget gnupg2
+RUN apt-get update && apt-get install -y wget gnupg2 gettext-base
 
 # Add key
 RUN wget -O - http://ppa.moosefs.com/moosefs.key 2>/dev/null | apt-key add - 2>/dev/null

--- a/moosefs-metalogger/metalogger.sh
+++ b/moosefs-metalogger/metalogger.sh
@@ -6,5 +6,14 @@ MFS_ENV="${MFS_ENV:-PROD}"
 # Set a correct owner
 chown -R mfs:mfs /var/lib/mfs
 
+# Overwrite mfsmetalogger.cfg if passed in
+# this will base64 decode MFS_METALOGGER_CONFIG variable text
+# substitute any env variables in decoded text
+# save text into /etc/mfs/mfsmetalogger.cfg
+if [ ! -z ${MFS_METALOGGER_CONFIG+X} ];
+    then
+        echo $MFS_METALOGGER_CONFIG | base64 -d | envsubst > /etc/mfs/mfsmetalogger.cfg
+fi
+
 # Run
 exec mfsmetalogger -f


### PR DESCRIPTION
I'm running this in k8s cluster and had modified a few things so that I'm able to generate and save configurations for containers when they are created. That way I can pass in variables that contain correct information in k8s cluster so that the whole storage spins up correctly.