### PR TITLE
fix for overriding MFS_HDD_CONFIG by static content

### DIFF
--- a/moosefs-chunkserver/chunkserver.sh
+++ b/moosefs-chunkserver/chunkserver.sh
@@ -20,15 +20,14 @@ fi
 if [ ! -z ${MFS_HDD_CONFIG+X} ];
     then
         echo $MFS_HDD_CONFIG | base64 -d | envsubst > /etc/mfs/mfshdd.cfg
-fi
-
-
-#Add size to hdd if defined
-if [ -z ${SIZE+X} ];
-    then
-        echo "/mnt/hdd0" > /etc/mfs/mfshdd.cfg
-    else
-        echo "/mnt/hdd0 ${SIZE}GiB" > /etc/mfs/mfshdd.cfg
+else
+  #Add size to hdd if defined
+  if [ -z ${SIZE+X} ];
+      then
+          echo "/mnt/hdd0" > /etc/mfs/mfshdd.cfg
+      else
+          echo "/mnt/hdd0 ${SIZE}GiB" > /etc/mfs/mfshdd.cfg
+  fi
 fi
 
 # Add label if defined


### PR DESCRIPTION
I think I found a bug in the code. 
Regardless of what we pass in the MFS_HDD_CONFIG environment variable, the value is overwritten by the "echo" command on lines 29 or 31.
My solution: when the MFS_HDD_CONFIG variable is used, it leaves the user fully responsible for the content of the mfshdd.cfg file. 